### PR TITLE
defer属性を付けて表示を早くする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "short-cut-extension",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "short-cut-extension",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
-        "bootstrap": "^5.0.0",
-        "jquery": "^3.6.0",
-        "jquery-ui": "^1.13.2",
+        "bootstrap": "^5.3.7",
+        "jquery": "^3.7.1",
+        "jquery-ui": "^1.14.1",
         "moment": "~2.29.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -52,6 +52,9 @@
         "webpack": "^5.99.9",
         "webpack-cli": "^6.0.1",
         "webpack-merge": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4127,9 +4130,9 @@
       "license": "MIT"
     },
     "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "short-cut-extension",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "short-cut-extension",
   "main": "index.js",
   "scripts": {
@@ -18,9 +18,9 @@
     "url": "https://github.com/satoshi-nishinaka/chrome-extension-study.git"
   },
   "dependencies": {
-    "bootstrap": "^5.0.0",
-    "jquery": "^3.6.0",
-    "jquery-ui": "^1.13.2",
+    "bootstrap": "^5.3.7",
+    "jquery": "^3.7.1",
+    "jquery-ui": "^1.14.1",
     "moment": "~2.29.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ShortCut Extension",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "manifest_version": 3,
   "background": {
     "service_worker": "js/background.js"

--- a/public/popup.html
+++ b/public/popup.html
@@ -5,13 +5,13 @@
     <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link rel="stylesheet" href="css/style.css" />
-    <script type="text/javascript" src="js/vendor.js"></script>
-    <script type="text/javascript" src="js/popup.js"></script>
 </head>
 
 <body id="short-cut-extension">
     <div id="root"></div>
-    <script type="text/javascript" src="js/popupContainer.js"></script>
+    <script type="text/javascript" src="js/vendor.js" defer></script>
+    <script type="text/javascript" src="js/popup.js" defer></script>
+    <script type="text/javascript" src="js/popupContainer.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
# Issue
なし

# 内容
ポップアップの表示が遅いのでScriptタグに `defer` 属性を付けて表示を早くする
refs: [<script> タグに async / defer を付けた場合のタイミング #JavaScript - Qiita](https://qiita.com/phanect/items/82c85ea4b8f9c373d684)

# セルフチェック
- [x] ソースコードのチェック
- [x] `npm run build` が通るか
- [x] lintチェック済みか
